### PR TITLE
implementation link made relative

### DIFF
--- a/srfi-257.html
+++ b/srfi-257.html
@@ -1352,7 +1352,7 @@ Sample <code>syntax-rules</code>-based implementation is available.
 It runs on many R6RS and R7RS and some R5RS Schemes.
 </p>
 
-<a href="https://malgil.com/esl/srfi/xm11.scm">Source for the sample implementation.</a>
+<a href="xm11.scm">Source for the sample implementation.</a>
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 


### PR DESCRIPTION
Arthur, I think it's better to link to the implementation file in the github repo.

Thanks, 
-S