### PR TITLE
Third draft

### DIFF
--- a/srfi-257-rx-test.scm
+++ b/srfi-257-rx-test.scm
@@ -1,0 +1,308 @@
+(import (scheme base) (srfi 64))
+(import (srfi 257) (srfi 257 rx) (srfi 264))
+
+; SRFI 257 RX Tests (some of them borrowed)
+
+(test-begin "srfi-257-rx")
+
+(test-equal #f 
+  (match 42 ((~/ "[0-9]+" a) a) (_ #f)))
+
+(test-equal "42" 
+  (match "42" ((~/ "[0-9]+" a) a) (_ #f)))
+
+(test-equal #f 
+  (match 42 ((~/ (rx (+ (/ "09"))) a) a) (_ #f)))
+
+(test-equal "42" 
+  (match "42" ((~/ (rx (+ (/ "09"))) a) a) (_ #f)))
+
+(define phs "home: 301-123-4567; cell: 240-890-1234; fax: 301-567-8901")
+
+(test-equal '("home" "301" "123" "4567") 
+  (match phs ((~/sub "({a}*): ({d}*)-({d}*)-({d}*)" _ t a b c) (list t a b c)) (_ #f)))
+
+(test-equal '("home" "301" "123" "4567") 
+  (match phs ((~/any "({a}*): ({d}*)-({d}*)-({d}*)" _ t a b c) (list t a b c)) (_ #f)))
+
+(test-equal #f
+  (match phs ((~/sub "({a}*): ({d}*)-({d}*)-({d}*)" _ t "240" b c) (list t "240" b c)) (_ #f)))
+
+(test-equal '("cell" "240" "890" "1234") 
+  (match phs ((~/any "({a}*): ({d}*)-({d}*)-({d}*)" _ t "240" b c) (list t "240" b c)) (_ #f)))
+
+(test-equal '("cell" "240" "890" "1234") 
+  (match phs ((~/any "({a}*): ({d}*)-({d}*)-({d}*)" _ t (~and a (~not "301")) b c) (list t a b c)) (_ #f)))
+
+(test-equal #f 
+  (match phs ((~/any "({a}*): ({d}*)-({d}*)-({d}*)" _ t "412" b c) (list t "412" b c)) (_ #f)))
+
+(test-equal #f 
+  (match phs ((~/all "({a}*): ({d}*)-({d}*)-({d}*)" _ t "412" b c) (list t "412" b c)) (_ #f)))
+
+(test-equal '(("home" "cell" "fax") ("301" "240" "301")) 
+  (match phs ((~/all "({a}*): ({d}*)-({d}*)-({d}*)" _ t a) (list t a)) (_ #f)))
+
+(test-equal #f 
+  (match phs ((~/etc "({a}*): ({d}*)-({d}*)-({d}*)" _ t (~and a (~not "240"))) (list t a)) (_ #f)))
+
+(test-equal '(("home" "fax") ("301" "301")) 
+  (match phs ((~/etcse "({a}*): ({d}*)-({d}*)-({d}*)" _ t (~and a (~not "240"))) (list t a)) (_ #f)))
+
+(test-equal '(() ()) 
+  (match phs ((~/etcse "({a}*): ({d}*)-({d}*)-({d}*)" _ t (~and a "412")) (list t a)) (_ #f)))
+
+
+;;;; tests below adapted from the SRE ref. imp. tests by Alex Shinn
+;;;; by selectively converting regexes to SSRE strings
+
+;;;; SPDX-FileCopyrightText: 2015 - 2019 Alex Shinn
+;;;;
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(test-equal '("ababc" "abab") 
+  (match "ababc" ((~/ (rx ($ (* "ab")) "c") a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab") 
+  (match "ababc" ((~/ "((?:ab)*)c" a b) (list a b)) (_ #f)))
+
+(test-equal '("y") 
+  (match "xy" ((~/any (rx "y") a) (list a)) (_ #f)))
+(test-equal '("y") 
+  (match "xy" ((~/any "y" a) (list a)) (_ #f)))
+
+(test-equal '("ababc" "abab") 
+  (match "xababc" ((~/any (rx ($ (* "ab")) "c") a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab") 
+  (match "xababc" ((~/any "((?:ab)*)c" a b) (list a b)) (_ #f)))
+
+(test-equal #f 
+  (match "fooxbafba" ((~/ (rx (* any) ($ "foo" (* any)) ($ "bar" (* any)))) (list)) (_ #f)))
+(test-equal #f
+  (match "fooxbafba" ((~/ "{_}*(foo{_}*)(bar{_}*)") (list)) (_ #f)))
+
+(test-equal '("fooxbarfbar" "fooxbarf" "bar")
+  (match "fooxbarfbar" ((~/ (rx (* any) ($ "foo" (* any)) ($ "bar" (* any))) a b c) (list a b c)) (_ #f)))
+(test-equal '("fooxbarfbar" "fooxbarf" "bar")
+  (match "fooxbarfbar" ((~/ "{_}*(foo{_}*)(bar{_}*)" a b c) (list a b c)) (_ #f)))
+
+(test-equal '("abcd" "abcd")
+  (match "abcd" ((~/ (rx ($ (* (or "ab" "cd")))) a b) (list a b)) (_ #f)))
+(test-equal '("abcd" "abcd")
+  (match "abcd" ((~/ "((?:ab|cd)*)" a b) (list a b)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx bos ($ (* "ab")) "c") a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "^((?:ab)*)c" a b) (list a b)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx ($ (* "ab")) "c" eos) a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "((?:ab)*)c$" a b) (list a b)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx bos ($ (* "ab")) "c" eos) a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "^((?:ab)*)c$" a b) (list a b)) (_ #f)))
+
+(test-equal #f
+  (match "ababc" ((~/ (rx bos ($ (* "ab")) eos "c")) (list)) (_ #f)))
+(test-equal #f
+  (match "ababc" ((~/ "^((?:ab)*)$c") (list)) (_ #f)))
+
+(test-equal #f
+  (match "ababc" ((~/ (rx ($ (* "ab")) bos "c" eos)) (list)) (_ #f)))
+(test-equal #f
+  (match "ababc" ((~/ "((?:ab)*)^c$") (list)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx bol ($ (* "ab")) "c") a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "{<l}((?:ab)*)c" a b) (list a b)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx ($ (* "ab")) "c" eol) a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "((?:ab)*)c{l>}" a b) (list a b)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx bol ($ (* "ab")) "c" eol) a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "{<l}((?:ab)*)c{l>}" a b) (list a b)) (_ #f)))
+
+(test-equal #f
+  (match "ababc" ((~/ (rx bol ($ (* "ab")) eol "c")) (list)) (_ #f)))
+(test-equal #f
+  (match "ababc" ((~/ "{<l}((?:ab)*){l>}c") (list)) (_ #f)))
+
+(test-equal #f 
+  (match "ababc" ((~/ (rx ($ (* "ab")) bol "c" eol)) (list)) (_ #f)))
+(test-equal #f
+  (match "ababc" ((~/ "((?:ab)*){<l}c{l>}") (list)) (_ #f)))
+
+(test-equal '("\nabc\n" "abc")
+  (match "\nabc\n" ((~/ (rx (* #\newline) bol ($ (* alpha)) eol (* #\newline)) a b) (list a b)) (_ #f)))
+(test-equal '("\nabc\n" "abc")
+  (match "\nabc\n" ((~/ "\n*{<l}({a}*){l>}\n*" a b) (list a b)) (_ #f)))
+
+(test-equal #f 
+  (match "\n'abc\n" ((~/ (rx (* #\newline) bol ($ (* alpha)) eol (* #\newline))) (list)) (_ #f)))
+(test-equal #f 
+  (match "\n'abc\n" ((~/ "\n*{<l}({a}*){l>}\n*") (list)) (_ #f)))
+
+(test-equal #f
+  (match "\nabc.\n" ((~/ (rx (* #\newline) bol ($ (* alpha)) eol (* #\newline))) (list)) (_ #f)))
+(test-equal #f 
+  (match "\nabc.\n" ((~/ "\n*{<l}({a}*){l>}\n*") (list)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx bow ($ (* "ab")) "c") a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "\\<((?:ab)*)c" a b) (list a b)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx ($ (* "ab")) "c" eow) a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "((?:ab)*)c\\>" a b) (list a b)) (_ #f)))
+
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ (rx bow ($ (* "ab")) "c" eow) a b) (list a b)) (_ #f)))
+(test-equal '("ababc" "abab")
+  (match "ababc" ((~/ "\\<((?:ab)*)c\\>" a b) (list a b)) (_ #f)))
+
+(test-equal #f
+  (match "ababc" ((~/ (rx bow ($ (* "ab")) eow "c")) (list)) (_ #f)))
+(test-equal #f
+  (match "ababc" ((~/ "\\<((?:ab)*)\\>c") (list)) (_ #f)))
+
+(test-equal #f 
+  (match "ababc" ((~/ (rx ($ (* "ab")) bow "c" eow)) (list)) (_ #f)))
+(test-equal #f 
+  (match "ababc" ((~/ "((?:ab)*)\\<c\\>") (list)) (_ #f)))
+
+(test-equal '("  abc  " "abc")
+  (match "  abc  " ((~/ (rx (* space) bow ($ (* alpha)) eow (* space)) a b) (list a b)) (_ #f)))
+(test-equal '("  abc  " "abc")
+  (match "  abc  " ((~/ "\\s*\\<({a}*)\\>\\s*" a b) (list a b)) (_ #f)))
+
+(test-equal #f 
+  (match " 'abc  " ((~/ (rx (* space) bow ($ (* alpha)) eow (* space))) (list)) (_ #f)))
+(test-equal #f 
+  (match " 'abc  " ((~/ "\\s*\\<({a}*)\\>\\s*") (list)) (_ #f)))
+
+(test-equal #f
+  (match " abc.  " ((~/ (rx (* space) bow ($ (* alpha)) eow (* space))) (list)) (_ #f)))
+(test-equal #f 
+  (match " abc.  " ((~/ "\\s*\\<({a}*)\\>\\s*") (list)) (_ #f)))
+
+(test-equal '("abc  " "abc")
+  (match "abc  " ((~/ (rx ($ (* alpha)) (* any)) a b) (list a b)) (_ #f)))
+(test-equal '("abc  " "abc")
+  (match "abc  " ((~/ "({a}*){_}*" a b) (list a b)) (_ #f)))
+
+(test-equal '("abc  " "")
+  (match "abc  " ((~/ (rx ($ (*? alpha)) (* any)) a b) (list a b)) (_ #f)))
+(test-equal '("abc  " "")
+  (match "abc  " ((~/ "({a}*?){_}*" a b) (list a b)) (_ #f)))
+
+(test-equal '("<em>Hello World</em>" "em>Hello World</em")
+  (match "<em>Hello World</em>" ((~/ (rx "<" ($ (* any)) ">" (* any)) a b) (list a b)) (_ #f)))
+(test-equal '("<em>Hello World</em>" "em>Hello World</em")
+  (match "<em>Hello World</em>" ((~/ "<({_}*)>{_}*" a b) (list a b)) (_ #f)))
+
+(test-equal '("<em>Hello World</em>" "em")
+  (match "<em>Hello World</em>" ((~/ (rx "<" ($ (*? any)) ">" (* any)) a b) (list a b)) (_ #f)))
+(test-equal '("<em>Hello World</em>" "em")
+  (match "<em>Hello World</em>" ((~/ "<({_}*?)>{_}*" a b) (list a b)) (_ #f)))
+
+(test-equal '("foo")
+  (match " foo " ((~/any (rx "foo") a) (list a)) (_ #f)))
+(test-equal '("foo")
+  (match " foo " ((~/any "foo" a) (list a)) (_ #f)))
+
+(test-equal #f 
+  (match " foo " ((~/any (rx nwb "foo" nwb)) (list)) (_ #f)))
+(test-equal #f
+  (match " foo " ((~/any "\\Bfoo\\B") (list)) (_ #f)))
+
+(test-equal '("foo")
+  (match "xfoox" ((~/any (rx nwb "foo" nwb) a) (list a)) (_ #f)))
+(test-equal '("foo")
+  (match "xfoox" ((~/any "\\Bfoo\\B" a) (list a)) (_ #f)))
+
+(test-equal '("beef")
+  (match "beef" ((~/ (rx (* (/ "af"))) a) (list a)) (_ #f)))
+(test-equal '("beef")
+  (match "beef" ((~/ "[a-f]*" a) (list a)) (_ #f)))
+
+(test-equal '("12345beef" "beef")
+  (match "12345beef" ((~/ (rx (* numeric) ($ (* (/ "af")))) a b) (list a b)) (_ #f)))
+(test-equal '("12345beef" "beef")
+  (match "12345beef" ((~/ "\\d*([a-f]*)" a b) (list a b)) (_ #f)))
+
+(test-equal '("12345BeeF" "BeeF")
+  (match "12345BeeF" ((~/ (rx (* numeric) (w/nocase ($ (* (/ "af"))))) a b) (list a b)) (_ #f)))
+(test-equal '("12345BeeF" "BeeF")
+  (match "12345BeeF" ((~/ "\\d*(?i:([a-f]*))" a b) (list a b)) (_ #f)))
+
+(test-equal #f
+  (match "abcD" ((~/ (rx (* lower))) (list)) (_ #f)))
+(test-equal #f
+  (match "abcD" ((~/ "{l}*") (list)) (_ #f)))
+
+(test-equal '("abcD")
+  (match "abcD" ((~/ (rx (w/nocase (* lower))) a) (list a)) (_ #f)))
+(test-equal '("abcD")
+  (match "abcD" ((~/ "(?i){l}*" a) (list a)) (_ #f)))
+
+(test-equal '("123" "456" "789")
+  (match "abc123def456ghi789" ((~/extracted (rx (+ numeric)) l) l))) 
+(test-equal '("123" "456" "789")
+  (match "abc123def456ghi789" ((~/extracted "{d}+" l) l))) 
+
+(test-equal '("123" "456" "789")
+  (match "abc123def456ghi789" ((~/extracted (rx (* numeric)) l) l))) 
+(test-equal '("123" "456" "789")
+  (match "abc123def456ghi789" ((~/extracted "[\\d]*" l) l))) 
+
+(test-equal '("abc" "def" "ghi" "")
+  (match "abc123def456ghi789" ((~/split  (rx (* numeric)) l) l))) 
+(test-equal '("abc" "def" "ghi" "")
+  (match "abc123def456ghi789" ((~/split  "{d}*" l) l)))
+
+(test-equal '("abc" "def" "ghi" "")
+  (match "abc123def456ghi789" ((~/split  (rx (+ numeric)) l) l)))
+(test-equal '("abc" "def" "ghi" "")
+  (match "abc123def456ghi789" ((~/split  "\\d+" l) l)))
+
+(test-equal '("a" "b") 
+  (match "a b" ((~/split  (rx (+ whitespace)) l) l)))
+(test-equal '("a" "b") 
+  (match "a b" ((~/split  "{s}+" l) l)))
+
+(test-equal '("a" "" "b") 
+  (match "a,,b" ((~/split  (rx (",;")) l) l)))
+(test-equal '("a" "" "b") 
+  (match "a,,b" ((~/split  "[,;]" l) l)))
+
+(test-equal '("a" "" "b" "") 
+  (match "a,,b," ((~/split  (rx (",;")) l) l)))
+(test-equal '("a" "" "b" "") 
+  (match "a,,b," ((~/split  "[,;]" l) l)))
+      
+(test-equal '("")
+  (match "" ((~/partitioned (rx (* numeric)) l) l)))
+(test-equal '("")
+  (match "" ((~/partitioned "{d}*" l) l)))
+
+(test-equal '("abc" "123" "def" "456" "ghi")
+  (match "abc123def456ghi" ((~/partitioned (rx (* numeric)) l) l)))
+(test-equal '("abc" "123" "def" "456" "ghi")
+  (match "abc123def456ghi" ((~/partitioned "{d}*" l) l)))
+
+(test-equal '("abc" "123" "def" "456" "ghi" "789")
+  (match "abc123def456ghi789" ((~/partitioned (rx (* numeric)) l) l)))
+(test-equal '("abc" "123" "def" "456" "ghi" "789")
+  (match "abc123def456ghi789" ((~/partitioned "{d}*" l) l)))
+
+(test-end)

--- a/srfi-257.html
+++ b/srfi-257.html
@@ -69,6 +69,7 @@ SPDX-License-Identifier: MIT
     <ul>
       <li><a href="#sublibs-misc">The ‘misc’ sublibrary</a></li>
       <li><a href="#sublibs-box">The ‘box’ sublibrary</a></li>
+      <li><a href="#sublibs-rx">The ‘rx’ sublibrary</a></li>
       <li><a href="#optional-features">Optional features</a></li>
     </ul>
   </li>
@@ -774,6 +775,15 @@ The <code>~cons</code> pattern matches a pair whose <i>car</i>  matches
   by <code>~etc</code> pattern on a successful match.
 </p>
 
+<p>
+  <code>(<b>~etcse</b></code> ⟨<i>mp</i> ⟩<code>)</code>
+    &nbsp;&nbsp;<i>match pattern</i><br>
+  The <code>~etcse</code> pattern works similarly to the <code>~etc</code> pattern,
+  but it never fails on proper lists (‘sine errore’ mode). If an element of 
+  the input list does not match the ⟨<i>mp</i> ⟩ subpattern, it is skipped. 
+</p>
+
+
 <h3 id="vector-patterns">Vector patterns</h3>
 
 <p>
@@ -935,7 +945,7 @@ results of individual sub-pattern matches.
   <code>(<b>~and</b></code> ⟨<i>mp</i> ⟩ …<code>)</code>
     &nbsp;&nbsp;<i>match pattern</i><br>
 This pattern matches if <em>all</em> its sub-patterns match the input object. If
-sub-patterns contain pattern values, all of them are bound on a successful match. If there
+sub-patterns contain pattern variables, all of them are bound on a successful match. If there
 are no sub-patterns, the <code>(~and)</code> pattern matches any object.
 </p>
 
@@ -945,8 +955,8 @@ are no sub-patterns, the <code>(~and)</code> pattern matches any object.
 This pattern matches if <em>any</em> of its sub-patterns matches the input object. The
 sub-patterns are tried in the order they are written, and the process stops on
 the first sub-pattern that matches successfully (but see the note below). If sub-patterns
-contain pattern values, all of them are bound on a match, but only the ones
-belonging to the “successful” sub-pattern will have their values bound to the
+contain pattern variables, all of them are bound on a match, but only the ones
+belonging to the “successful” sub-pattern will have their variables bound to the
 corresponding sub-values. The remaining variables are bound to <code>#f</code>.
 If there are no sub-patterns, the <code>(~or)</code> pattern fails on every object.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;<i>Note:</i>  this pattern is iterative in the following
@@ -959,7 +969,8 @@ one is tried, then the next one, etc.
     &nbsp;&nbsp;<i>match pattern</i><br>
 This pattern matches if its sub-pattern fails to match the input object. If
 it contains pattern variables, none of them are bound on a successful match
-(i.e. when the sub-pattern fails).
+(i.e. when the sub-pattern fails). It is an error for a pattern to refer to
+the same pattern variable inside and outside of a <code>~not</code> pattern.
 </p>
 
 <h3 id="compatibility-patterns">Compatibility patterns</h3>
@@ -1275,10 +1286,11 @@ which variables are unrolled and which are replicated are explicit.<br>
 <h2 id="sublibs">Sublibraries and optional features</h2>
 
 <p>
-In addition to the above syntax forms exported by the main <code>(srfi 257)</code> library, 
-there are two utility libraries, which could be defined portably in terms of the core but
-are provided as convenience extensions. The <code>box</code> sublibrary is defined
-conditionally, based on support for <a href="/srfi-111/">SRFI 111</a>.
+In addition to the above syntax forms exported by the main <code>(srfi 257)</code> library,
+there are three utility libraries, which could be defined portably in terms of the core but
+are provided as convenience extensions. The <code>box</code> and <code>rx</code> sublibraries
+are defined conditionally, based on support for <a href="/srfi-111/">SRFI 111</a> and
+<a href="/srfi-115/">SRFI 115</a>/<a href="/srfi-264/">SRFI 264</a> respectively.
 </p>
 
 <h3 id="sublibs-misc">The ‘misc’ sublibrary</h3>
@@ -1292,22 +1304,22 @@ The <code>(srfi 257 misc)</code> sublibrary exports miscellaneous forms defined 
     &nbsp;&nbsp;<i>match pattern</i><br>
   The <code>~etc+</code> pattern matches a proper nonempty list such that every one
   of its elements matches ⟨<i>mp</i> ⟩. It is equivalent to the <code>~etc</code> pattern,
-  constrained to fail on empty lists. 
+  constrained to fail on empty lists.
 </p>
 
 <p>
   <code>(<b>~etc=</b></code> ⟨<i>lp</i> ⟩ ⟨<i>mp</i> ⟩<code>)</code>
     &nbsp;&nbsp;<i>match pattern</i><br>
   The <code>~etc=</code> pattern matches a proper list such that its length matches the
-  ⟨<i>lp</i> ⟩ pattern, and every one of its elements matches the ⟨<i>mp</i> ⟩ pattern. 
-  It is equivalent to the <code>~etc</code> pattern, constrained by list length. 
+  ⟨<i>lp</i> ⟩ pattern, and every one of its elements matches the ⟨<i>mp</i> ⟩ pattern.
+  It is equivalent to the <code>~etc</code> pattern, constrained by list length.
 </p>
 
 <p>
   <code>(<b>~etc**</b></code> ⟨<i>k</i> ⟩ ⟨<i>j</i> ⟩ ⟨<i>mp</i> ⟩<code>)</code>
     &nbsp;&nbsp;<i>match pattern</i><br>
   The <code>~etc**</code> pattern matches a proper list such that its length lies in a range,
-  defined by the ⟨<i>k</i> ⟩ and ⟨<i>j</i> ⟩ expressions (inclusive), and every one of its elements matches the ⟨<i>mp</i> ⟩ pattern. 
+  defined by the ⟨<i>k</i> ⟩ and ⟨<i>j</i> ⟩ expressions (inclusive), and every one of its elements matches the ⟨<i>mp</i> ⟩ pattern.
   It is equivalent to the <code>~etc</code> pattern, constrained by list length.<br/>
   &nbsp;&nbsp;&nbsp;&nbsp;<i>Note:</i>  The first two arguments are expressions, evaluated
   each time the pattern is considered for a match.<br>
@@ -1316,7 +1328,7 @@ The <code>(srfi 257 misc)</code> sublibrary exports miscellaneous forms defined 
 <p>
   <code>(<b>cm-match</b></code> ⟨<i>expression</i> ⟩ ⟨<i>cm-rule</i> ⟩<code> &hellip;)</code>
     &nbsp;&nbsp;<i>syntax</i><br>
-  The <code>cm-match</code> form implements a variant of Dybvig-Friedman-Hilsdale 
+  The <code>cm-match</code> form implements a variant of Dybvig-Friedman-Hilsdale
   matcher, as specified in <a href="/srfi-241/">SRFI 241</a>. Compared to the original, <code>cm-match</code>
   is more compact, but it does not implement D-F-H matcher's enhanced right-hand-side <code>quasiquote</code>.
 </p>
@@ -1328,22 +1340,22 @@ The <code>(srfi 257 misc)</code> sublibrary exports miscellaneous forms defined 
   -like pattern conventions: a symbolic pattern is treated as ⟨<i>match pattern name</i> ⟩
   unless it is contained in the list of ⟨<i>literals</i> ⟩. Each ⟨<i>sr-rule</i> ⟩
   is similar to the regular ⟨<i>match rule</i> ⟩ as described in the main specification,
-  with the following change: instead of ⟨<i>match pattern</i> ⟩, 
+  with the following change: instead of ⟨<i>match pattern</i> ⟩,
   ⟨<i>sr-rule</i> ⟩ starts with an ⟨<i>sr-pattern</i> ⟩, which is either an
-  empty list (matches itself), an ⟨<i>atomic datum</i> ⟩ (matches any 
+  empty list (matches itself), an ⟨<i>atomic datum</i> ⟩ (matches any
   <code>equal?</code> object), an ⟨<i>underscore</i> ⟩ (matches any object),
-  a ⟨<i>match pattern name</i> ⟩ (matches and binds any object), a ⟨<i>literal</i> ⟩ 
+  a ⟨<i>match pattern name</i> ⟩ (matches and binds any object), a ⟨<i>literal</i> ⟩
   (matches itself), or a pair/vector of ⟨<i>sr-pattern</i> ⟩s, matched recursively
   with a similarly-structured objects. If element of a list or vector is immediately followed
   by an ⟨<i>ellipsis</i> ⟩, this element is matched as if implicitly wrapped in <code>~etc</code>
-  pattern; as <code>syntax-rules</code>, <code>sr-match</code> does not support multiple 
-  ellipses on the same level.    
+  pattern; as <code>syntax-rules</code>, <code>sr-match</code> does not support multiple
+  ellipses on the same level.
 </p>
 
 <h3 id="sublibs-box">The ‘box’ sublibrary</h3>
 
 <p>
-Systems that support <a href="/srfi-111/">SRFI 111</a> may provide <code>(srfi 257 box)</code> 
+Systems that support <a href="/srfi-111/">SRFI 111</a> should provide <code>(srfi 257 box)</code>
 sublibrary exporting the following match patterns.
 </p>
 
@@ -1362,12 +1374,106 @@ combined with the <code>~and</code> pattern combinator.
   should match the ⟨<i>mp</i> ⟩ subpattern.
 </p>
 
+<h3 id="sublibs-rx">The ‘rx’ sublibrary</h3>
+
+<p>
+Systems that support <a href="/srfi-115/">SRFI 115</a> (Scheme Regular Expressions) and
+<a href="/srfi-264/">SRFI 264</a> (String syntax for Scheme Regular Expressions)
+should provide <code>(srfi 257 rx)</code> sublibrary exporting the following syntax and
+match patterns. All match patterns below fail on non-string input objects.
+</p>
+
+<p>
+<code>(<b>rx</b></code> ⟨<i>sre</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>syntax</i><br>
+The <code>rx</code> regexp constructor is reexported verbatim from SRFI 115, so
+there is no need to import it separately for simple uses.
+</p>
+
+<p>
+The ⟨<i>re</i> ⟩ argument in all patterns below is an expression that should evaluate
+to either a regexp (e.g. be a <code>rx</code> macro use), or to a string, which is expected to
+be in <a href="/srfi-264/">SRFI 264</a> SSRE regexp notation. All other arguments are match
+patterns. Procedures mentioned in the descriptions are from <a href="/srfi-115/">SRFI 115</a>.
+</p>
+
+<p>
+<code>(<b>~/</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+The <code>~/</code> pattern matches a string input object; its full contents
+should match the ⟨<i>re</i> ⟩ regexp, as specified by the <code>regexp-matches</code> procedure.
+The ⟨<i>mp</i> ⟩&hellip; subpatterns, as many as present, should match the corresponding regexp submatch
+strings: first ⟨<i>mp</i> ⟩ should match submatch 0 (the whole input string), the second
+⟨<i>mp</i> ⟩ should match the first regexp capture group, and so on. Note: ⟨<i>mp</i> ⟩s match
+the initial elements of the list returned by the <code>regexp-match->list</code> procedure;
+the pattern will fail if there are more ⟨<i>mp</i> ⟩s than strings returned by the procedure.
+</p>
+
+<pre><code>(<b>match</b> "foo:123" [(~/ "([a-z]*):([0-9]*)" s aa dd) (list s aa dd)] [_ #f])
+⟹ ("foo:123" "foo" "123")
+</code></pre>
+
+<p>
+<code>(<b>~/sub</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+This pattern is similar to the <code>~/</code> pattern above, but it allows the ⟨<i>re</i> ⟩ regexp to match
+a substring of the input string, as specified by the <code>regexp-search</code> procedure. The
+first matching substring and its corresponding capture groups strings are matched against
+the ⟨<i>mp</i> ⟩s.
+</p>
+
+<p>
+<code>(<b>~/any</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>match pattern (iterative)</i><br>
+Similar to the <code>~/sub</code> pattern above, but is able to look beyond the first match, trying
+all matches in order until if finds the substring and its corresponding capture groups strings
+that match the ⟨<i>mp</i> ⟩s. Fails if there are no successful matches.
+</p>
+
+<p>
+<code>(<b>~/all</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+<code>(<b>~/all+</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+<code>(<b>~/etc</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+<code>(<b>~/etc+</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+<code>(<b>~/etcse</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩&hellip;<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+These patterns extract all substrings of the input string matched by the ⟨<i>re</i> ⟩ regexp,
+as specified by the <code>regexp-fold</code> procedure. The ‘all’ match patterns do not
+fail even if ⟨<i>re</i> ⟩ matches no substrings; the ‘+’ ones fail if no substrings are found.
+In the first pair of patterns, the ⟨<i>mp</i> ⟩&hellip; subpatterns are matched against the parallel 
+lists of the submatch/capture strings as described above; their original order in the input string 
+is preserved.
+The ‘etc’/‘etc+’ patterns wrap their ⟨<i>mp</i> ⟩&hellip; subpatterns in an impilcit <code>~etc</code>
+pattern, so they are matched against individual substrings before being aggregated into lists. This 
+is useful if additional constraints need to be set on individual substrings to filter the resulting lists.
+The ‘etcse’ pattern wraps its ⟨<i>mp</i> ⟩&hellip; subpatterns in an impilicit <code>~etcse</code>
+pattern, skipping matches that fail the subpattern constraints. Thus, the <code>~/etcse</code> pattern 
+never fails on any input string.  
+</p>
+
+<p>
+<code>(<b>~/extracted</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+<code>(<b>~/split</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+<code>(<b>~/partitioned</b></code> ⟨<i>re</i> ⟩ ⟨<i>mp</i> ⟩<code>)</code>
+  &nbsp;&nbsp;<i>match pattern</i><br>
+These patterns extract all substrings of the input string matched by the ⟨<i>re</i> ⟩ regexp,
+and/or in-between substrings, as specified by the <code>regexp-extract</code>, <code>regexp-split</code>, and
+<code>regexp-partition</code> procedures respectively. The ⟨<i>mp</i> ⟩ subpattern is
+matched against the list of the corresponding substrings; their original order in the input string is preserved.
+</p>
+
 
 <h3 id="optional-features">Optional features</h3>
 
 <p>
   Systems that support boxes and <code>#&amp;</code> read syntax for box literals (e.g. Chez Scheme)
-  may support box literal patterns as part of ⟨<i>match pattern</i> ⟩, as well as both 
+  may support box literal patterns as part of ⟨<i>match pattern</i> ⟩, as well as both
   <code>cm-match</code> and <code>sr-match</code> patterns.
 </p>
 
@@ -1380,7 +1486,7 @@ combined with the <code>~and</code> pattern combinator.
 
 <p>
 This appendix gives possible definitions for some derived pattern types in terms of
-the basic and core pattern types.
+the basic, logical, and core pattern types.
 </p>
 
 <pre><code>(<b>define-match-pattern</b> ~value ()
@@ -1477,6 +1583,7 @@ Andrew K. Wright, Robert Cartwright, Alex Shinn, R. Kent Dybvig, Dan Friedman, E
 Chris Hanson, Gerald Jay Sussman, Marc Nieper-Wißkirchen, Dimitris Vyzovitis, Felix Thibault,
 and Panicz Maciej Godek.
 I am grateful to Andrew Pochinsky, Daphne Preston-Kendal, and John Cowan for their feedback.
+Special thanks to Al* Petrofsky and Oleg Kiselyov for lessons in advanced macrology.
 </p>
 
 <h2 id="copyright">Copyright</h2>

--- a/srfi-257.html
+++ b/srfi-257.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <!--
-SPDX-FileCopyrightText: 2024 Sergei Egorov
+SPDX-FileCopyrightText: 2024-2025 Sergei Egorov
 SPDX-License-Identifier: MIT
 -->
   <head>
@@ -28,6 +28,7 @@ SPDX-License-Identifier: MIT
       <li>Received: 2024-12-27</li>
       <li>60-day deadline: 2024-02-27</li>
       <li>Draft #1 published: 2024-12-29</li>
+      <li>Draft #2 published: 2025-04-18</li>
     </ul>
 
 <h2 id="toc">Table of contents</h2>
@@ -779,8 +780,8 @@ The <code>~cons</code> pattern matches a pair whose <i>car</i>  matches
   <code>(<b>~etcse</b></code> ⟨<i>mp</i> ⟩<code>)</code>
     &nbsp;&nbsp;<i>match pattern</i><br>
   The <code>~etcse</code> pattern works similarly to the <code>~etc</code> pattern,
-  but it never fails on proper lists (‘sine errore’ mode). If an element of 
-  the input list does not match the ⟨<i>mp</i> ⟩ subpattern, it is skipped. 
+  but it never fails on proper lists (‘sine errore’ mode). If an element of
+  the input list does not match the ⟨<i>mp</i> ⟩ subpattern, it is skipped.
 </p>
 
 
@@ -1444,15 +1445,15 @@ that match the ⟨<i>mp</i> ⟩s. Fails if there are no successful matches.
 These patterns extract all substrings of the input string matched by the ⟨<i>re</i> ⟩ regexp,
 as specified by the <code>regexp-fold</code> procedure. The ‘all’ match patterns do not
 fail even if ⟨<i>re</i> ⟩ matches no substrings; the ‘+’ ones fail if no substrings are found.
-In the first pair of patterns, the ⟨<i>mp</i> ⟩&hellip; subpatterns are matched against the parallel 
-lists of the submatch/capture strings as described above; their original order in the input string 
+In the first pair of patterns, the ⟨<i>mp</i> ⟩&hellip; subpatterns are matched against the parallel
+lists of the submatch/capture strings as described above; their original order in the input string
 is preserved.
 The ‘etc’/‘etc+’ patterns wrap their ⟨<i>mp</i> ⟩&hellip; subpatterns in an impilcit <code>~etc</code>
-pattern, so they are matched against individual substrings before being aggregated into lists. This 
+pattern, so they are matched against individual substrings before being aggregated into lists. This
 is useful if additional constraints need to be set on individual substrings to filter the resulting lists.
 The ‘etcse’ pattern wraps its ⟨<i>mp</i> ⟩&hellip; subpatterns in an impilicit <code>~etcse</code>
-pattern, skipping matches that fail the subpattern constraints. Thus, the <code>~/etcse</code> pattern 
-never fails on any input string.  
+pattern, skipping matches that fail the subpattern constraints. Thus, the <code>~/etcse</code> pattern
+never fails on any input string.
 </p>
 
 <p>

--- a/srfi/257.sld
+++ b/srfi/257.sld
@@ -8,7 +8,8 @@
     _ ... => quote quasiquote unquote unquote-splicing
     match
     ~value 
-    ~cons ~list ~append ~append/ng ~append/t ~etc
+    ~cons ~list ~append ~append/ng ~append/t 
+    ~etc ~etcse ; et cetera sine errore
     ~vector ~vector-append ~vector-append/ng
     ~string ~string-append ~string-append/ng
     ~vector->list ~string->list ~list->vector
@@ -99,7 +100,7 @@
            ((_ ev uv (x . y)  k . a*) (subx ev uv x subcdr ev uv y k . a*))
            ;((_ ev uv #&x k . a*) (subx ev uv x rebox k . a*))
            ((_ ev uv #(x (... ...)) k . a*) (subx ev uv (x (... ...)) revec k . a*))
-           ((_ ev uv x k . a*) (classify x (k ev . a*) (k uv . a*) (k x . a*) (syntax-error "r-s?")))))
+           ((_ ev uv x k . a*) (classify x (k ev . a*) (k uv . a*) (k x . a*) (k x . a*)))))
         (subcdr
          (syntax-rules ()
            ((_ sx ev uv y k . a*) (subx ev uv y repair sx k . a*))))
@@ -519,7 +520,7 @@
 
 
 ;
-; 6)  ~etc: ... - like list matcher
+; 6)  ~etc: ... - like list matchers
 ;
 
 ; Nonlinear part of ~etc works as follows: code for p is generated in
@@ -555,6 +556,25 @@
               (let ((axv (car lxv)) (dxv (cdr lxv)))
                 (let-syntax ((n (syntax-rules () ((_ k . a*) (k () . a*)))))
                   (submatch axv p (b n) (loop dxv (cons v t) ...) kf))))
+             (else kf))))))
+
+(define-syntax ~etcse ; sine errore
+  (syntax-rules ()
+    ((_ () (p) (n) kt ()) ; scan for vars
+     (submatch () p (n) kt ()))
+    ((_ xv (p) c kt kf)
+     (extract-pattern-vars p (~etcse xv p c kt kf)))
+    ((_ (v ...) (t ...) xv p (b n) kt kf)
+     (let loop ((lxv xv) (t '()) ...)
+       (cond ((null? lxv)
+              (if (n match:etc-nl-test (v ...) (t ...) ())
+                  (let ((v (reverse t)) ...) kt)
+                  kf))
+             ((pair? lxv)
+              (let ((axv (car lxv)) (dxv (cdr lxv)))
+                (let-syntax ((n (syntax-rules () ((_ k . a*) (k () . a*)))))
+                  (submatch axv p (b n) ; just skip failed submatches 
+                    (loop dxv (cons v t) ...) (loop dxv t ...)))))
              (else kf))))))
 
 

--- a/srfi/257/rx.sld
+++ b/srfi/257/rx.sld
@@ -1,0 +1,103 @@
+;;; SPDX-FileCopyrightText: 2025 Sergei Egorov
+;;; SPDX-License-Identifier: MIT
+
+(define-library (srfi 257 rx)
+  (import (scheme base) (srfi 115) (srfi 257) (srfi 264))
+  (export 
+    rx ; re-exported from srfi 115
+    ~/ ~/sub ~/any ~/all ~/all+ ~/etc ~/etcse ~/etc+ 
+    ~/extracted ~/split ~/partitioned)
+
+(begin
+
+(define (ssorx x)
+  (cond ((regexp? x) x)
+        ((string? x) (ssre->regexp x)) ; assumed to be cached
+        (else (error "regexp match pattern expects an SSRE string or a regexp argument" x))))
+
+(define (regexp-search-all/list-of-matches re str)
+  (define (kons i m str acc) (cons m acc)) 
+  (define (finish i m str acc) (reverse acc))
+  (regexp-fold re kons '() str finish))
+
+(define (regexp-search-all/list-of-match-lists re str)
+  (define (kons i m str acc) 
+    (cons (regexp-match->list m) acc)) 
+  (define (finish i m str acc) 
+    (reverse acc))
+  (regexp-fold re kons '() str finish))
+
+(define (regexp-search-all/list-of-submatch-lists re str)
+  (define (empty-lists) ; returned on no matches 
+    (let ((el (list '()))) (set-cdr! el el) el))
+  (define (kons i m str acc) 
+    (let ((l (regexp-match->list m)))
+      (if (null? acc) (map list l) (map cons l acc))))
+  (define (finish i m str acc) 
+    (if (null? acc) (empty-lists) (map reverse acc)))
+  (regexp-fold re kons '() str finish))
+
+(define-match-pattern ~/ ()
+  ((~/ x) 
+   (~test (lambda (s) (and (string? s) (regexp-matches? (ssorx x) s)))))
+  ((~/ x spat ...) ; $0, $1, ...
+   (~test (lambda (s) (and (string? s) (regexp-matches (ssorx x) s))) => 
+     (~prop regexp-match->list => (~list* spat ... _)))))
+
+(define-match-pattern ~/sub ()
+  ((~/sub x) 
+   (~test (lambda (s) (and (string? s) (regexp-search (ssorx x) s)))))
+  ((~/sub x spat ...) ; $0, $1, ...
+   (~test (lambda (s) (and (string? s) (regexp-search (ssorx x) s))) => 
+     (~prop regexp-match->list => (~list* spat ... _)))))
+
+(define-syntax any:start
+  (syntax-rules () ((_ xv try f) (if (pair? xv) (try xv) (f)))))
+(define-syntax any:head 
+  (syntax-rules () ((_ xv) (regexp-match->list (car xv)))))
+(define-syntax any:tail
+  (syntax-rules () ((_ try f xv) (if (pair? (cdr xv)) (try (cdr xv)) (f)))))
+
+(define-match-pattern ~/any ()
+  ((~/any x spat ...) ; $0, $1, ...
+   (~string? (~prop (lambda (s) (regexp-search-all/list-of-matches (ssorx x) s)) => 
+                (~iterate any:start any:head any:tail (l) (~list* spat ... _))))))
+
+(define-match-pattern ~/all ()
+  ((~/all x s*pat ...) ; $0*, $1*, ...
+   (~string? (~prop (lambda (s) (regexp-search-all/list-of-submatch-lists (ssorx x) s)) => 
+                (~list* s*pat ... _)))))
+
+(define-match-pattern ~/all+ ()
+  ((~/+ x s*pat ...) ; $0*, $1*, ...
+   (~string? (~prop (lambda (s) (regexp-search-all (ssorx x) s)) => 
+                (~pair? (~list* s*pat ... _))))))
+
+(define-match-pattern ~/etc ()
+  ((~/etc x spat ...) ; $0, $1, ...
+   (~string? (~prop (lambda (s) (regexp-search-all/list-of-match-lists (ssorx x) s)) => 
+                (~etc (~list* spat ... _))))))
+
+(define-match-pattern ~/etc+ ()
+  ((~/+ x spat ...) ; $0, $1, ...
+   (~string? (~prop (lambda (s) (regexp-search-all/list-of-match-lists (ssorx x) s)) => 
+                (~pair? (~etc (~list* spat ... _)))))))
+
+(define-match-pattern ~/etcse ()
+  ((~/etcse x spat ...) ; $0, $1, ...
+   (~string? (~prop (lambda (s) (regexp-search-all/list-of-match-lists (ssorx x) s)) => 
+                (~etcse (~list* spat ... _))))))               
+
+(define-match-pattern ~/extracted ()
+  ((~/extracted x s*pat)
+   (~string? (~prop (lambda (s) (regexp-extract (ssorx x) s)) => s*pat))))
+
+(define-match-pattern ~/split ()
+  ((~/s x s*pat)
+   (~string? (~prop (lambda (s) (regexp-split (ssorx x) s)) => s*pat))))
+
+(define-match-pattern ~/partitioned ()
+  ((~/partitioned x s*pat)
+   (~string? (~prop (lambda (s) (regexp-partition (ssorx x) s)) => s*pat))))
+
+))

--- a/xm11.scm
+++ b/xm11.scm
@@ -82,7 +82,7 @@
            ((_ ev uv (x . y)  k . a*) (subx ev uv x subcdr ev uv y k . a*))
            ;((_ ev uv #&x k . a*) (subx ev uv x rebox k . a*))
            ((_ ev uv #(x (... ...)) k . a*) (subx ev uv (x (... ...)) revec k . a*))
-           ((_ ev uv x k . a*) (classify x (k ev . a*) (k uv . a*) (k x . a*) (syntax-error "r-s?")))))
+           ((_ ev uv x k . a*) (classify x (k ev . a*) (k uv . a*) (k x . a*) (k x . a*)))))
         (subcdr
          (syntax-rules ()
            ((_ sx ev uv y k . a*) (subx ev uv y repair sx k . a*))))
@@ -502,7 +502,7 @@
 
 
 ;
-; 6)  ~etc: ... - like list matcher
+; 6)  ~etc: ... - like list matchers
 ;
 
 ; Nonlinear part of ~etc works as follows: code for p is generated in
@@ -538,6 +538,25 @@
               (let ((axv (car lxv)) (dxv (cdr lxv)))
                 (let-syntax ((n (syntax-rules () ((_ k . a*) (k () . a*)))))
                   (submatch axv p (b n) (loop dxv (cons v t) ...) kf))))
+             (else kf))))))
+
+(define-syntax ~etcse ; sine errore
+  (syntax-rules ()
+    ((_ () (p) (n) kt ()) ; scan for vars
+     (submatch () p (n) kt ()))
+    ((_ xv (p) c kt kf)
+     (extract-pattern-vars p (~etcse xv p c kt kf)))
+    ((_ (v ...) (t ...) xv p (b n) kt kf)
+     (let loop ((lxv xv) (t '()) ...)
+       (cond ((null? lxv)
+              (if (n match:etc-nl-test (v ...) (t ...) ())
+                  (let ((v (reverse t)) ...) kt)
+                  kf))
+             ((pair? lxv)
+              (let ((axv (car lxv)) (dxv (cdr lxv)))
+                (let-syntax ((n (syntax-rules () ((_ k . a*) (k () . a*)))))
+                  (submatch axv p (b n) ; just skip failed submatches 
+                    (loop dxv (cons v t) ...) (loop dxv t ...)))))
              (else kf))))))
 
 


### PR DESCRIPTION
Hi Arthur,

Here is the third draft of the pattern matcher SRFI. The changes are:

- added `~etcse` pattern; it is similar to `~etc`, but skips elements that failed to match (‘et cetera sine errore’)
- added 'rx' sub-library (depends on SRFIs 115, 264)
- added 'rx' sub-library tests (based on SRFI 64; depends on SRFIs 115, 264)
- minor editing & bug fixes

To make your life a bit easier, I have changed all text files to LF-only line endings and removed trailing spaces )

Thanks!
--Sergei
